### PR TITLE
Ignore intelliJ configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# intelliJ configs
+.idea


### PR DESCRIPTION
Ignore .idea folder from IntelliJ software that contains the user IDE configuration files